### PR TITLE
Connection adapter commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## v1.3.0 - February 26, 2016
 
-* Possibility to deploy resource adapters when creating domain
-* Support for 3 new commands when creating domain (create-connector-connection-pool, create-connector-resource, create-admin-object)
+* Possibility to deploy resource adapters (RA) when creating domain
+* Support for 4 new commands when creating domain (create-resource-adapter-config, create-connector-connection-pool, create-connector-resource, create-admin-object)
 
 ## v1.2.2 - April 17, 2015
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.3.0 - February 26, 2016
+
+* Possibility to deploy resource adapters when creating domain
+* Support for 3 new commands when creating domain (create-connector-connection-pool, create-connector-resource, create-admin-object)
+
 ## v1.2.2 - April 17, 2015
 
 * Fixed undeploy command.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <plugin>
 	<groupId>com.lotaris.maven.plugins</groupId>
 	<artifactId>lotaris-glassfish-maven-plugin</artifactId>
-	<version>1.2.2</version>
+	<version>1.3.0</version>
 	<executions>
 		<execution>
 			<id>glassfish</id>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>com.lotaris.maven.plugins</groupId>
 	<artifactId>lotaris-glassfish-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
-	<version>1.3.0-SNAPSHOT</version>
+	<version>1.3.0</version>
 	
 	<name>Lotaris Glassfish Maven Plugin</name>
 	<description>Glassfish Asadmin maven plugin with full arguments supported through XML pom configuration.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>com.lotaris.maven.plugins</groupId>
 	<artifactId>lotaris-glassfish-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
-	<version>1.2.3-SNAPSHOT</version>
+	<version>1.3.0-SNAPSHOT</version>
 	
 	<name>Lotaris Glassfish Maven Plugin</name>
 	<description>Glassfish Asadmin maven plugin with full arguments supported through XML pom configuration.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>com.lotaris.maven.plugins</groupId>
 	<artifactId>lotaris-glassfish-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
-	<version>1.2.2</version>
+	<version>1.2.3-SNAPSHOT</version>
 	
 	<name>Lotaris Glassfish Maven Plugin</name>
 	<description>Glassfish Asadmin maven plugin with full arguments supported through XML pom configuration.</description>
@@ -26,6 +26,11 @@
 			<name>Laurent Prevost</name>
 			<email>laurent.prevost@lotaris.com</email>
 			<organization>https://github.com/lotaris</organization>
+		</developer>
+		<developer>
+			<name>Valentin Delaye</name>
+			<email>valentin.delaye@novaccess.ch</email>
+			<organization>http://www.novaccess.ch</organization>
 		</developer>
 	</developers>
 

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/CreateDomainGlassfishMojo.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/CreateDomainGlassfishMojo.java
@@ -4,13 +4,11 @@ import com.lotaris.maven.plugin.glassfish.macro.AbstractMacro;
 import com.lotaris.maven.plugin.glassfish.macro.CreateDomainMacro;
 import com.lotaris.maven.plugin.glassfish.model.Configuration;
 import com.lotaris.maven.plugin.glassfish.model.ConnectionFactory;
-import com.lotaris.maven.plugin.glassfish.model.DeployConfiguration;
 import com.lotaris.maven.plugin.glassfish.model.JdbcResource;
 import com.lotaris.maven.plugin.glassfish.model.Property;
 import java.lang.reflect.Field;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Create a new domain in a local or remote Glassfish instance
@@ -20,9 +18,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 @Mojo(name = "create-domain", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST, requiresProject = true)
 public class CreateDomainGlassfishMojo extends GlassfishMojo {
 	
-	@Parameter(required = false)
-	private DeployConfiguration deployConfig;
-	
 	@Override
 	protected AbstractMacro getMacro() {
 		return new CreateDomainMacro(configuration);
@@ -30,7 +25,7 @@ public class CreateDomainGlassfishMojo extends GlassfishMojo {
 	
 	@Override
 	protected Configuration buildConfiguration() {
-		Configuration config = new Configuration(getLog(), glassfish, domain, deployConfig);
+		Configuration config = new Configuration(getLog(), glassfish, domain);
 		
 		if (domain.getConnectionFactories() != null) {
 			// Ensure that the configuration of JMS Connection factories are well configured

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/CreateDomainGlassfishMojo.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/CreateDomainGlassfishMojo.java
@@ -4,11 +4,13 @@ import com.lotaris.maven.plugin.glassfish.macro.AbstractMacro;
 import com.lotaris.maven.plugin.glassfish.macro.CreateDomainMacro;
 import com.lotaris.maven.plugin.glassfish.model.Configuration;
 import com.lotaris.maven.plugin.glassfish.model.ConnectionFactory;
+import com.lotaris.maven.plugin.glassfish.model.DeployConfiguration;
 import com.lotaris.maven.plugin.glassfish.model.JdbcResource;
 import com.lotaris.maven.plugin.glassfish.model.Property;
 import java.lang.reflect.Field;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Create a new domain in a local or remote Glassfish instance
@@ -17,6 +19,10 @@ import org.apache.maven.plugins.annotations.Mojo;
  */
 @Mojo(name = "create-domain", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST, requiresProject = true)
 public class CreateDomainGlassfishMojo extends GlassfishMojo {
+	
+	@Parameter(required = false)
+	private DeployConfiguration deployConfig;
+	
 	@Override
 	protected AbstractMacro getMacro() {
 		return new CreateDomainMacro(configuration);
@@ -24,7 +30,7 @@ public class CreateDomainGlassfishMojo extends GlassfishMojo {
 	
 	@Override
 	protected Configuration buildConfiguration() {
-		Configuration config = new Configuration(getLog(), glassfish, domain);
+		Configuration config = new Configuration(getLog(), glassfish, domain, deployConfig);
 		
 		if (domain.getConnectionFactories() != null) {
 			// Ensure that the configuration of JMS Connection factories are well configured

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandFactory.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandFactory.java
@@ -2,6 +2,7 @@ package com.lotaris.maven.plugin.glassfish.command;
 
 import com.lotaris.maven.plugin.glassfish.model.Configuration;
 import com.lotaris.maven.plugin.glassfish.model.ConnectionFactory;
+import com.lotaris.maven.plugin.glassfish.model.ConnectorConnectionPool;
 
 import com.lotaris.maven.plugin.glassfish.model.JmsResource;
 import com.lotaris.maven.plugin.glassfish.model.Property;
@@ -11,6 +12,7 @@ import java.util.Set;
 import static com.lotaris.maven.plugin.glassfish.command.CommandName.*;
 import static com.lotaris.maven.plugin.glassfish.command.argument.CommandArgumentFactory.*;
 import static com.lotaris.maven.plugin.glassfish.command.argument.CommandArgumentName.*;
+
 import com.lotaris.maven.plugin.glassfish.model.DeployConfiguration;
 import com.lotaris.maven.plugin.glassfish.model.JdbcResource;
 import com.lotaris.maven.plugin.glassfish.model.JmsHost;
@@ -498,6 +500,16 @@ public class CommandFactory {
 			addArgument(buildBooleanArgument(DEP_CASCADE, configuration.getUndeployConfiguration().getCascade())).
 			addArgument(buildStringArgument(DEP_FILE, configuration.getUndeployConfiguration().getName())).
 			setFriendlyErrorMessage("Unable to undeploy the component.");
+	}
+	
+	public static CommandBuilder buildCreateConnectorConnectionPoolCommand(Configuration configuration, ConnectorConnectionPool connectorConnectionPool) {
+		return create(CREATE_CONNECTOR_CONNECTION_POOL, configuration).
+			addArgument(buildStringArgument(RANAME, connectorConnectionPool.getRaname())).
+			addArgument(buildStringArgument(CONNECTION_DEFINITION, connectorConnectionPool.getConnectionDefinition().getClazz())).
+			addArgument(buildBooleanArgument(PING, connectorConnectionPool.getPing())).
+			addArgument(buildBooleanArgument(IS_CONNECT_VALIDATE_REQ, connectorConnectionPool.getIsConnectValidateReq())).
+			addArgument(buildStringArgument(JNDI_NAME, connectorConnectionPool.getJndiName())).
+			setFriendlyErrorMessage("Unable to create the connector connection pool.");		
 	}
 	
 	/**

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandFactory.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandFactory.java
@@ -1,5 +1,6 @@
 package com.lotaris.maven.plugin.glassfish.command;
 
+import com.lotaris.maven.plugin.glassfish.model.AdminObject;
 import com.lotaris.maven.plugin.glassfish.model.Configuration;
 import com.lotaris.maven.plugin.glassfish.model.ConnectionFactory;
 import com.lotaris.maven.plugin.glassfish.model.ConnectorConnectionPool;
@@ -543,6 +544,22 @@ public class CommandFactory {
 			addArgument(buildStringArgument(CONNECTOR_RESOURCE_CONNECTION_POOL_NAME, connectorResource.getPoolName())).
 			addArgument(buildPropertyArgument(connectorResource.getProperties())).
 			addArgument(buildStringArgument(JNDI_NAME, connectorResource.getJndiName())).
+			setFriendlyErrorMessage("Unable to create the connector resource.");		
+	}
+	
+	/**
+	 * Build a create-admin-object command
+	 * 
+	 * @param configuration The configuration to enrich the command
+	 * @param adminObject The admin object
+	 * @return The command
+	 */
+	public static CommandBuilder buildCreateAdminObjectCommand(Configuration configuration, AdminObject adminObject) {
+		return create(CREATE_ADMIN_OBJECT, configuration).
+			addArgument(buildStringArgument(CONNECTOR_CONNECTION_POOL_RANAME, adminObject.getRaname())).
+			addArgument(buildStringArgument(RESOURCE_TYPE, adminObject.getRestype())).
+			addArgument(buildPropertyArgument(adminObject.getProperties())).
+			addArgument(buildStringArgument(JNDI_NAME, adminObject.getJndiName())).
 			setFriendlyErrorMessage("Unable to create the connector resource.");		
 	}
 	

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandFactory.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandFactory.java
@@ -3,6 +3,7 @@ package com.lotaris.maven.plugin.glassfish.command;
 import com.lotaris.maven.plugin.glassfish.model.Configuration;
 import com.lotaris.maven.plugin.glassfish.model.ConnectionFactory;
 import com.lotaris.maven.plugin.glassfish.model.ConnectorConnectionPool;
+import com.lotaris.maven.plugin.glassfish.model.ConnectorResource;
 
 import com.lotaris.maven.plugin.glassfish.model.JmsResource;
 import com.lotaris.maven.plugin.glassfish.model.Property;
@@ -521,13 +522,28 @@ public class CommandFactory {
 	 */
 	public static CommandBuilder buildCreateConnectorConnectionPoolCommand(Configuration configuration, ConnectorConnectionPool connectorConnectionPool) {
 		return create(CREATE_CONNECTOR_CONNECTION_POOL, configuration).
-			addArgument(buildStringArgument(RANAME, connectorConnectionPool.getRaname())).
-			addArgument(buildStringArgument(CONNECTION_DEFINITION, connectorConnectionPool.getConnectionDefinition().getClazz())).
-			addArgument(buildBooleanArgument(PING, connectorConnectionPool.getPing())).
-			addArgument(buildBooleanArgument(IS_CONNECT_VALIDATE_REQ, connectorConnectionPool.getIsConnectValidateReq())).
+			addArgument(buildStringArgument(CONNECTOR_CONNECTION_POOL_RANAME, connectorConnectionPool.getRaname())).
+			addArgument(buildStringArgument(CONNECTOR_CONNECTION_POOL_CONNECTION_DEFINITION, connectorConnectionPool.getConnectionDefinition())).
+			addArgument(buildBooleanArgument(CONNECTOR_CONNECTION_POOL_PING, connectorConnectionPool.getPing())).
+			addArgument(buildBooleanArgument(CONNECTOR_CONNECTION_POOL_IS_CONNECT_VALIDATE_REQ, connectorConnectionPool.getIsConnectValidateReq())).
 			addArgument(buildPropertyArgument(connectorConnectionPool.getProperties())).
 			addArgument(buildStringArgument(JNDI_NAME, connectorConnectionPool.getJndiName())).
 			setFriendlyErrorMessage("Unable to create the connector connection pool.");		
+	}
+	
+	/**
+	 * Build a create-connector-resource command
+	 * 
+	 * @param configuration The configuration to enrich the command
+	 * @param connectorConnectionPool The connector resource
+	 * @return The command
+	 */
+	public static CommandBuilder buildCreateConnectorConnectionPoolCommand(Configuration configuration, ConnectorResource connectorResource) {
+		return create(CREATE_CONNECTOR_RESOURCE, configuration).
+			addArgument(buildStringArgument(CONNECTOR_RESOURCE_CONNECTION_POOL_NAME, connectorResource.getPoolName())).
+			addArgument(buildPropertyArgument(connectorResource.getProperties())).
+			addArgument(buildStringArgument(JNDI_NAME, connectorResource.getJndiName())).
+			setFriendlyErrorMessage("Unable to create the connector resource.");		
 	}
 	
 	/**

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandFactory.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandFactory.java
@@ -19,6 +19,7 @@ import com.lotaris.maven.plugin.glassfish.model.DeployConfiguration;
 import com.lotaris.maven.plugin.glassfish.model.JdbcResource;
 import com.lotaris.maven.plugin.glassfish.model.JmsHost;
 import com.lotaris.maven.plugin.glassfish.model.RedeployConfiguration;
+import com.lotaris.maven.plugin.glassfish.model.ResourceAdapter;
 
 /**
  * The command factory create the ASADMIN commands
@@ -530,6 +531,20 @@ public class CommandFactory {
 			addArgument(buildPropertyArgument(connectorConnectionPool.getProperties())).
 			addArgument(buildStringArgument(JNDI_NAME, connectorConnectionPool.getJndiName())).
 			setFriendlyErrorMessage("Unable to create the connector connection pool.");		
+	}	
+	
+	/**
+	 * Build a create-resource-adapter-config command
+	 * 
+	 * @param configuration The configuration to enrich the command
+	 * @param resourceAdapter  The resource adapter to configure
+	 * @return The command
+	 */
+	public static CommandBuilder buildCreateAdapterConfigCommand(Configuration configuration, ResourceAdapter resourceAdapter) {
+		return create(CREATE_RESOURCE_ADAPTER_CONFIG, configuration).
+			addArgument(buildPropertyArgument(resourceAdapter.getProperties())).
+			addArgument(buildStringArgument(RESOURCE_ADAPTER_NAME, resourceAdapter.getDeployConfig().getName())).
+			setFriendlyErrorMessage("Unable to configure the resource adapter.");		
 	}
 	
 	/**

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandFactory.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandFactory.java
@@ -324,42 +324,52 @@ public class CommandFactory {
 	}
 	
 	/**
+	 * Build the deploy command with a custom deploy configuration
+	 * 
+	 * @param configuration The configuration to get the options for the deployment
+	 * @param deployConfig The deployment configuration
+	 * @return The command
+	 */
+	public static CommandBuilder buildDeployCommand(Configuration configuration, DeployConfiguration deployConfig) {
+
+		return create(DEPLOY, configuration).
+			addArgument(buildBooleanArgument(DEP_FORCE, deployConfig.getForce())).
+			addArgument(buildStringArgument(DEP_VIRTUAL_SERVERS, deployConfig.getVirtualServers())).
+			addArgument(buildStringArgument(DEP_CONTEXT_ROOT, deployConfig.getContextRoot())).
+			addArgument(buildBooleanArgument(DEP_PRE_COMPILE_JSP, deployConfig.getPreCompileJsp())).
+			addArgument(buildBooleanArgument(DEP_VERIFY, deployConfig.getVerify())).
+			addArgument(buildStringArgument(DEP_NAME, deployConfig.getName())).
+			addArgument(buildBooleanArgument(DEP_UPLOAD, deployConfig.getUpload())).
+			addArgument(buildStringArgument(DEP_RETRIEVE, deployConfig.getRetrieve())).
+			addArgument(buildStringArgument(DEP_DB_VENDOR_NAME, deployConfig.getDbVendorName())).
+			addArgument(buildBooleanArgument(DEP_CREATE_TABLES, deployConfig.getCreateTables())).
+			addArgument(buildBooleanArgument(DEP_DROP_AND_CREATE_TABLES, deployConfig.getDropAndCreateTables())).
+			addArgument(buildBooleanArgument(DEP_UNIQUE_TABLE_NAMES, deployConfig.getUniqueTableNames())).
+			addArgument(buildStringArgument(DEP_DEPLOYMENT_PLAN, deployConfig.getDeploymentPlan())).
+			addArgument(buildStringArgument(DEP_ALTDD, deployConfig.getAltdd())).
+			addArgument(buildStringArgument(DEP_RUNTIME_ATLDD, deployConfig.getRuntimeAltdd())).
+			addArgument(buildIntegerArgument(DEP_DEPLOYMENT_ORDER, deployConfig.getDeploymentOrder())).
+			addArgument(buildBooleanArgument(DEP_ENABLED, deployConfig.getEnabled())).
+			addArgument(buildBooleanArgument(DEP_GENERATE_RMI_STUBS, deployConfig.getGenerateRmiStubs())).
+			addArgument(buildBooleanArgument(DEP_AVAILABILITY_ENABLED, deployConfig.getAvailabilityEnabled())).
+			addArgument(buildBooleanArgument(DEP_ASYNCHRONOUS_REPLICATION, deployConfig.getAsynReplication())).
+			addArgument(buildBooleanArgument(DEP_LOAD_BALANCING_ENABLED, deployConfig.getLenabled())).
+			addArgument(buildBooleanArgument(DEP_KEEP_STATE, deployConfig.getKeepState())).
+			addArgument(buildStringArgument(DEP_LIBRARIES, deployConfig.getLibraries())).
+			addArgument(buildStringArgument(DEP_TYPE, deployConfig.getType())).
+			addArgument(buildDeploymentPropertyArgument(deployConfig.getProperties())).
+			addArgument(buildStringArgument(DEP_FILE, deployConfig.getFile())).
+			setFriendlyErrorMessage("Unable to deploy the component.");		
+	}
+	
+	/**
 	 * Build the deploy command
 	 * 
 	 * @param configuration The configuration to get the options for the deployment
 	 * @return The command
 	 */
 	public static CommandBuilder buildDeployCommand(Configuration configuration) {
-		DeployConfiguration depConfig = configuration.getDeployConfiguration();
-		
-		return create(DEPLOY, configuration).
-			addArgument(buildBooleanArgument(DEP_FORCE, depConfig.getForce())).
-			addArgument(buildStringArgument(DEP_VIRTUAL_SERVERS, depConfig.getVirtualServers())).
-			addArgument(buildStringArgument(DEP_CONTEXT_ROOT, depConfig.getContextRoot())).
-			addArgument(buildBooleanArgument(DEP_PRE_COMPILE_JSP, depConfig.getPreCompileJsp())).
-			addArgument(buildBooleanArgument(DEP_VERIFY, depConfig.getVerify())).
-			addArgument(buildStringArgument(DEP_NAME, depConfig.getName())).
-			addArgument(buildBooleanArgument(DEP_UPLOAD, depConfig.getUpload())).
-			addArgument(buildStringArgument(DEP_RETRIEVE, depConfig.getRetrieve())).
-			addArgument(buildStringArgument(DEP_DB_VENDOR_NAME, depConfig.getDbVendorName())).
-			addArgument(buildBooleanArgument(DEP_CREATE_TABLES, depConfig.getCreateTables())).
-			addArgument(buildBooleanArgument(DEP_DROP_AND_CREATE_TABLES, depConfig.getDropAndCreateTables())).
-			addArgument(buildBooleanArgument(DEP_UNIQUE_TABLE_NAMES, depConfig.getUniqueTableNames())).
-			addArgument(buildStringArgument(DEP_DEPLOYMENT_PLAN, depConfig.getDeploymentPlan())).
-			addArgument(buildStringArgument(DEP_ALTDD, depConfig.getAltdd())).
-			addArgument(buildStringArgument(DEP_RUNTIME_ATLDD, depConfig.getRuntimeAltdd())).
-			addArgument(buildIntegerArgument(DEP_DEPLOYMENT_ORDER, depConfig.getDeploymentOrder())).
-			addArgument(buildBooleanArgument(DEP_ENABLED, depConfig.getEnabled())).
-			addArgument(buildBooleanArgument(DEP_GENERATE_RMI_STUBS, depConfig.getGenerateRmiStubs())).
-			addArgument(buildBooleanArgument(DEP_AVAILABILITY_ENABLED, depConfig.getAvailabilityEnabled())).
-			addArgument(buildBooleanArgument(DEP_ASYNCHRONOUS_REPLICATION, depConfig.getAsynReplication())).
-			addArgument(buildBooleanArgument(DEP_LOAD_BALANCING_ENABLED, depConfig.getLenabled())).
-			addArgument(buildBooleanArgument(DEP_KEEP_STATE, depConfig.getKeepState())).
-			addArgument(buildStringArgument(DEP_LIBRARIES, depConfig.getLibraries())).
-			addArgument(buildStringArgument(DEP_TYPE, depConfig.getType())).
-			addArgument(buildDeploymentPropertyArgument(depConfig.getProperties())).
-			addArgument(buildStringArgument(DEP_FILE, depConfig.getFile())).
-			setFriendlyErrorMessage("Unable to deploy the component.");
+		return buildDeployCommand(configuration, configuration.getDeployConfiguration());
 	}
 	
 	/**
@@ -502,12 +512,20 @@ public class CommandFactory {
 			setFriendlyErrorMessage("Unable to undeploy the component.");
 	}
 	
+	/**
+	 * Build a create-connector-connection-pool command
+	 * 
+	 * @param configuration The configuration to enrich the command
+	 * @param connectorConnectionPool The connector connection pool
+	 * @return The command
+	 */
 	public static CommandBuilder buildCreateConnectorConnectionPoolCommand(Configuration configuration, ConnectorConnectionPool connectorConnectionPool) {
 		return create(CREATE_CONNECTOR_CONNECTION_POOL, configuration).
 			addArgument(buildStringArgument(RANAME, connectorConnectionPool.getRaname())).
 			addArgument(buildStringArgument(CONNECTION_DEFINITION, connectorConnectionPool.getConnectionDefinition().getClazz())).
 			addArgument(buildBooleanArgument(PING, connectorConnectionPool.getPing())).
 			addArgument(buildBooleanArgument(IS_CONNECT_VALIDATE_REQ, connectorConnectionPool.getIsConnectValidateReq())).
+			addArgument(buildPropertyArgument(connectorConnectionPool.getProperties())).
 			addArgument(buildStringArgument(JNDI_NAME, connectorConnectionPool.getJndiName())).
 			setFriendlyErrorMessage("Unable to create the connector connection pool.");		
 	}

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandName.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandName.java
@@ -94,7 +94,12 @@ public enum CommandName {
 	/**
 	 * Create a connector connection pool
 	 */
-	CREATE_CONNECTOR_CONNECTION_POOL("create-connector-connection-pool");
+	CREATE_CONNECTOR_CONNECTION_POOL("create-connector-connection-pool"),
+	
+	/**
+	 * Create a connector resource
+	 */
+	CREATE_CONNECTOR_RESOURCE("create-connector-resource");
 	
 	/**
 	 * Command name used in the command line

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandName.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandName.java
@@ -99,7 +99,12 @@ public enum CommandName {
 	/**
 	 * Create a connector resource
 	 */
-	CREATE_CONNECTOR_RESOURCE("create-connector-resource");
+	CREATE_CONNECTOR_RESOURCE("create-connector-resource"),
+	
+	/**
+	 * Create an admin object
+	 */
+	CREATE_ADMIN_OBJECT("create-admin-object");
 	
 	/**
 	 * Command name used in the command line

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandName.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandName.java
@@ -6,6 +6,22 @@ package com.lotaris.maven.plugin.glassfish.command;
  * @author Laurent Prevost, laurent.prevost@lotaris.com
  */
 public enum CommandName {
+	
+	/**
+	 * Create an admin object
+	 */
+	CREATE_ADMIN_OBJECT("create-admin-object"),
+	
+	/**
+	 * Create a connector connection pool
+	 */
+	CREATE_CONNECTOR_CONNECTION_POOL("create-connector-connection-pool"),
+	
+	/**
+	 * Create a connector resource
+	 */
+	CREATE_CONNECTOR_RESOURCE("create-connector-resource"),
+
 	/**
 	 * Creation of a new domain
 	 */
@@ -15,7 +31,7 @@ public enum CommandName {
 	 * Create a JDBC connection pool
 	 */
 	CREATE_JDBC_CONNECTION_POOL("create-jdbc-connection-pool"),
-	
+		
 	/**
 	 * Create the JMS host
 	 */
@@ -40,6 +56,11 @@ public enum CommandName {
 	 * Creation of a new JVM option
 	 */
 	CREATE_JVM_OPTIONS("create-jvm-options"),
+	
+	/**
+	 * Create a resource adapter config
+	 */
+	CREATE_RESOURCE_ADAPTER_CONFIG("create-resource-adapter-config"),
 	
 	/**
 	 * Delete an existing domain
@@ -89,27 +110,7 @@ public enum CommandName {
 	/**
 	 * Undeploy an application
 	 */
-	UNDEPLOY("undeploy"),
-	
-	/**
-	 * Create a resource adapter config
-	 */
-	CREATE_RESOURCE_ADAPTER_CONFIG("create-resource-adapter-config"),
-	
-	/**
-	 * Create a connector connection pool
-	 */
-	CREATE_CONNECTOR_CONNECTION_POOL("create-connector-connection-pool"),
-	
-	/**
-	 * Create a connector resource
-	 */
-	CREATE_CONNECTOR_RESOURCE("create-connector-resource"),
-	
-	/**
-	 * Create an admin object
-	 */
-	CREATE_ADMIN_OBJECT("create-admin-object");
+	UNDEPLOY("undeploy");
 	
 	/**
 	 * Command name used in the command line

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandName.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandName.java
@@ -92,6 +92,11 @@ public enum CommandName {
 	UNDEPLOY("undeploy"),
 	
 	/**
+	 * Create a resource adapter config
+	 */
+	CREATE_RESOURCE_ADAPTER_CONFIG("create-resource-adapter-config"),
+	
+	/**
 	 * Create a connector connection pool
 	 */
 	CREATE_CONNECTOR_CONNECTION_POOL("create-connector-connection-pool"),

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandName.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/command/CommandName.java
@@ -89,7 +89,12 @@ public enum CommandName {
 	/**
 	 * Undeploy an application
 	 */
-	UNDEPLOY("undeploy");
+	UNDEPLOY("undeploy"),
+	
+	/**
+	 * Create a connector connection pool
+	 */
+	CREATE_CONNECTOR_CONNECTION_POOL("create-connector-connection-pool");
 	
 	/**
 	 * Command name used in the command line

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/command/argument/CommandArgumentName.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/command/argument/CommandArgumentName.java
@@ -457,7 +457,27 @@ public enum CommandArgumentName implements IArgumentName {
 	/**
 	 * Argument for the set command
 	 */
-	SET_ATTRIBUTE(null);
+	SET_ATTRIBUTE(null),
+	
+	/**
+	 * Name of the resource adapter
+	 */
+	RANAME("raname"),
+	
+	/**
+	 * The connection definition
+	 */
+	CONNECTION_DEFINITION("connectiondefinition"),
+	
+	/**
+	 * Ping during creation
+	 */
+	PING("ping"),
+	
+	/**
+	 * If connections are checked before use
+	 */
+	IS_CONNECT_VALIDATE_REQ("isconnectvalidatereq");
 	
 	/**
 	 * Argument name

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/command/argument/CommandArgumentName.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/command/argument/CommandArgumentName.java
@@ -482,7 +482,12 @@ public enum CommandArgumentName implements IArgumentName {
 	/**
 	 * The connector resource connection pool name
 	 */
-	CONNECTOR_RESOURCE_CONNECTION_POOL_NAME("poolName");
+	CONNECTOR_RESOURCE_CONNECTION_POOL_NAME("poolName"),
+	
+	/**
+	 * The resource adapter (RA) name
+	 */
+	RESOURCE_ADAPTER_NAME(null);
 	
 	/**
 	 * Argument name

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/command/argument/CommandArgumentName.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/command/argument/CommandArgumentName.java
@@ -462,22 +462,27 @@ public enum CommandArgumentName implements IArgumentName {
 	/**
 	 * Name of the resource adapter
 	 */
-	RANAME("raname"),
+	CONNECTOR_CONNECTION_POOL_RANAME("raname"),
 	
 	/**
 	 * The connection definition
 	 */
-	CONNECTION_DEFINITION("connectiondefinition"),
+	CONNECTOR_CONNECTION_POOL_CONNECTION_DEFINITION("connectiondefinition"),
 	
 	/**
 	 * Ping during creation
 	 */
-	PING("ping"),
+	CONNECTOR_CONNECTION_POOL_PING("ping"),
 	
 	/**
 	 * If connections are checked before use
 	 */
-	IS_CONNECT_VALIDATE_REQ("isconnectvalidatereq");
+	CONNECTOR_CONNECTION_POOL_IS_CONNECT_VALIDATE_REQ("isconnectvalidatereq"),
+	
+	/**
+	 * The connector resource connection pool name
+	 */
+	CONNECTOR_RESOURCE_CONNECTION_POOL_NAME("poolName");
 	
 	/**
 	 * Argument name

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/command/argument/CommandArgumentName.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/command/argument/CommandArgumentName.java
@@ -12,6 +12,31 @@ public enum CommandArgumentName implements IArgumentName {
 	ADMIN_PORT("adminport"),
 	
 	/**
+	 * The connection definition
+	 */
+	CONNECTOR_CONNECTION_POOL_CONNECTION_DEFINITION("connectiondefinition"),
+	
+	/**
+	 * If connections are checked before use
+	 */
+	CONNECTOR_CONNECTION_POOL_IS_CONNECT_VALIDATE_REQ("isconnectvalidatereq"),
+	
+	/**
+	 * Ping during creation
+	 */
+	CONNECTOR_CONNECTION_POOL_PING("ping"),
+	
+	/**
+	 * Name of the resource adapter
+	 */
+	CONNECTOR_CONNECTION_POOL_RANAME("raname"),
+	
+	/**
+	 * The connector resource connection pool name
+	 */
+	CONNECTOR_RESOURCE_CONNECTION_POOL_NAME("poolName"),
+	
+	/**
 	 * Description text
 	 */
 	DESCRIPTION("description"),
@@ -450,6 +475,11 @@ public enum CommandArgumentName implements IArgumentName {
 	PROPERTY("property"),
 	
 	/**
+	 * The resource adapter (RA) name
+	 */
+	RESOURCE_ADAPTER_NAME(null),
+	
+	/**
 	 * Resource type for JMS/JDBC
 	 */
 	RESOURCE_TYPE("restype"),
@@ -457,37 +487,8 @@ public enum CommandArgumentName implements IArgumentName {
 	/**
 	 * Argument for the set command
 	 */
-	SET_ATTRIBUTE(null),
+	SET_ATTRIBUTE(null);
 	
-	/**
-	 * Name of the resource adapter
-	 */
-	CONNECTOR_CONNECTION_POOL_RANAME("raname"),
-	
-	/**
-	 * The connection definition
-	 */
-	CONNECTOR_CONNECTION_POOL_CONNECTION_DEFINITION("connectiondefinition"),
-	
-	/**
-	 * Ping during creation
-	 */
-	CONNECTOR_CONNECTION_POOL_PING("ping"),
-	
-	/**
-	 * If connections are checked before use
-	 */
-	CONNECTOR_CONNECTION_POOL_IS_CONNECT_VALIDATE_REQ("isconnectvalidatereq"),
-	
-	/**
-	 * The connector resource connection pool name
-	 */
-	CONNECTOR_RESOURCE_CONNECTION_POOL_NAME("poolName"),
-	
-	/**
-	 * The resource adapter (RA) name
-	 */
-	RESOURCE_ADAPTER_NAME(null);
 	
 	/**
 	 * Argument name

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/macro/AdminObjectsMacro.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/macro/AdminObjectsMacro.java
@@ -1,0 +1,33 @@
+package com.lotaris.maven.plugin.glassfish.macro;
+
+import com.lotaris.maven.plugin.glassfish.model.AdminObject;
+import com.lotaris.maven.plugin.glassfish.model.Configuration;
+
+import static com.lotaris.maven.plugin.glassfish.command.CommandFactory.*;
+
+
+/**
+ * The Admin Object macro manage the creation of the different admin object
+ * 
+ * @author Valentin Delaye <valentin.delaye@novaccess.ch>
+ */
+public class AdminObjectsMacro extends AbstractMacro {
+	/**
+	 * Constructor
+	 * 
+	 * @param configuration The configuration
+	 */
+	public AdminObjectsMacro(Configuration configuration) {
+		super(configuration);
+
+		// Configure the Admin Objects if there are some
+		if (configuration.getDomain().hasAdminObjects()) {
+			
+			for (AdminObject adminobject : configuration.getDomain().getAdminObjects()) {
+				// Create and register the command
+				registerCommand(new MacroCommand(buildCreateAdminObjectCommand(configuration, adminobject), "Create the Admin Object [" + adminobject.getJndiName()+ "]."));
+			}
+		}
+		
+	}
+}

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/macro/ConnectorConnectionPoolsMacro.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/macro/ConnectorConnectionPoolsMacro.java
@@ -7,7 +7,7 @@ import static com.lotaris.maven.plugin.glassfish.command.CommandFactory.*;
 
 
 /**
- * The JMS Resource macro manage the creation of the different connector connection pool
+ * The Connector Connection Pool macro manage the creation of the different connector connection pool
  * 
  * @author Valentin Delaye <valentin.delaye@novaccess.ch>
  */

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/macro/ConnectorConnectionPoolsMacro.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/macro/ConnectorConnectionPoolsMacro.java
@@ -1,0 +1,34 @@
+package com.lotaris.maven.plugin.glassfish.macro;
+
+import com.lotaris.maven.plugin.glassfish.model.Configuration;
+import com.lotaris.maven.plugin.glassfish.model.ConnectorConnectionPool;
+
+import static com.lotaris.maven.plugin.glassfish.command.CommandFactory.*;
+
+
+/**
+ * The JMS Resource macro manage the creation of the different connector connection pool
+ * 
+ * @author Valentin Delaye <valentin.delaye@novaccess.ch>
+ */
+public class ConnectorConnectionPoolsMacro extends AbstractMacro {
+	/**
+	 * Constructor
+	 * 
+	 * @param configuration The configuration
+	 */
+	public ConnectorConnectionPoolsMacro(Configuration configuration) {
+		super(configuration);
+
+		
+		// Configure the JMS Hosts if there are some
+		if (configuration.getDomain().hasConnectorConnectionPools()) {
+			
+			for (ConnectorConnectionPool connectionPool : configuration.getDomain().getConnectorConnectionPools()) {
+				// Create and register the command
+				registerCommand(new MacroCommand(buildCreateConnectorConnectionPoolCommand(configuration, connectionPool), "Create the Connector connection pool [" + connectionPool.getJndiName()+ "]."));
+			}
+		}
+		
+	}
+}

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/macro/ConnectorConnectionPoolsMacro.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/macro/ConnectorConnectionPoolsMacro.java
@@ -20,8 +20,7 @@ public class ConnectorConnectionPoolsMacro extends AbstractMacro {
 	public ConnectorConnectionPoolsMacro(Configuration configuration) {
 		super(configuration);
 
-		
-		// Configure the JMS Hosts if there are some
+		// Configure the Conector Connection pool if there are some
 		if (configuration.getDomain().hasConnectorConnectionPools()) {
 			
 			for (ConnectorConnectionPool connectionPool : configuration.getDomain().getConnectorConnectionPools()) {

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/macro/ConnectorResourceMacro.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/macro/ConnectorResourceMacro.java
@@ -1,0 +1,33 @@
+package com.lotaris.maven.plugin.glassfish.macro;
+
+import com.lotaris.maven.plugin.glassfish.model.Configuration;
+import com.lotaris.maven.plugin.glassfish.model.ConnectorResource;
+
+import static com.lotaris.maven.plugin.glassfish.command.CommandFactory.*;
+
+
+/**
+ * The Connector Resource macro manage the creation of the different connector resource
+ * 
+ * @author Valentin Delaye <valentin.delaye@novaccess.ch>
+ */
+public class ConnectorResourceMacro extends AbstractMacro {
+	/**
+	 * Constructor
+	 * 
+	 * @param configuration The configuration
+	 */
+	public ConnectorResourceMacro(Configuration configuration) {
+		super(configuration);
+
+		// Configure the Conector Resource if there are some
+		if (configuration.getDomain().hasConnectorResources()) {
+			
+			for (ConnectorResource connectorResource : configuration.getDomain().getConnectorResources()) {
+				// Create and register the command
+				registerCommand(new MacroCommand(buildCreateConnectorConnectionPoolCommand(configuration, connectorResource), "Create the Connector resourc [" + connectorResource.getJndiName()+ "]."));
+			}
+		}
+		
+	}
+}

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/macro/ConnectorResourceMacro.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/macro/ConnectorResourceMacro.java
@@ -25,7 +25,7 @@ public class ConnectorResourceMacro extends AbstractMacro {
 			
 			for (ConnectorResource connectorResource : configuration.getDomain().getConnectorResources()) {
 				// Create and register the command
-				registerCommand(new MacroCommand(buildCreateConnectorConnectionPoolCommand(configuration, connectorResource), "Create the Connector resourc [" + connectorResource.getJndiName()+ "]."));
+				registerCommand(new MacroCommand(buildCreateConnectorConnectionPoolCommand(configuration, connectorResource), "Create the Connector resource [" + connectorResource.getJndiName()+ "]."));
 			}
 		}
 		

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/macro/CreateDomainMacro.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/macro/CreateDomainMacro.java
@@ -49,6 +49,7 @@ public class CreateDomainMacro extends AbstractMacro {
 		registerCommand(new MacroMacroCommand(new JdbcResourcesMacro(configuration), "Managing JDBC Resources."));
 		registerCommand(new MacroMacroCommand(new ResourceAdaptersMacro(configuration), "Managing deployment of Resource Adapter"));
 		registerCommand(new MacroMacroCommand(new ConnectorConnectionPoolsMacro(configuration), "Creating Connectors Connection Pools."));
+		registerCommand(new MacroMacroCommand(new ConnectorResourceMacro(configuration), "Creating Connectors Resources."));
 		registerCommand(new MacroCommand(buildStopDomainCommand(configuration), "Stopping domain."));
 	}
 }

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/macro/CreateDomainMacro.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/macro/CreateDomainMacro.java
@@ -47,9 +47,7 @@ public class CreateDomainMacro extends AbstractMacro {
 		registerCommand(new MacroCommand(buildSetLoggingAttributesCommand(configuration), "Setting the logging attributes."));
 		registerCommand(new MacroMacroCommand(new JmsResourcesMacro(configuration), "Managing JMS Resources."));
 		registerCommand(new MacroMacroCommand(new JdbcResourcesMacro(configuration), "Managing JDBC Resources."));
-		if(configuration.getDeployConfiguration() != null) {
-			registerCommand(new MacroMacroCommand(new DeployMacro(configuration), "Deploying resource adapter."));
-		}
+		registerCommand(new MacroMacroCommand(new ResourceAdaptersMacro(configuration), "Managing deployment of Resource Adapter"));
 		registerCommand(new MacroMacroCommand(new ConnectorConnectionPoolsMacro(configuration), "Creating Connectors Connection Pools."));
 		registerCommand(new MacroCommand(buildStopDomainCommand(configuration), "Stopping domain."));
 	}

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/macro/CreateDomainMacro.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/macro/CreateDomainMacro.java
@@ -50,6 +50,7 @@ public class CreateDomainMacro extends AbstractMacro {
 		registerCommand(new MacroMacroCommand(new ResourceAdaptersMacro(configuration), "Managing deployment of Resource Adapter"));
 		registerCommand(new MacroMacroCommand(new ConnectorConnectionPoolsMacro(configuration), "Creating Connectors Connection Pools."));
 		registerCommand(new MacroMacroCommand(new ConnectorResourceMacro(configuration), "Creating Connectors Resources."));
+		registerCommand(new MacroMacroCommand(new AdminObjectsMacro(configuration), "Creating Admin Object."));
 		registerCommand(new MacroCommand(buildStopDomainCommand(configuration), "Stopping domain."));
 	}
 }

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/macro/CreateDomainMacro.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/macro/CreateDomainMacro.java
@@ -47,6 +47,10 @@ public class CreateDomainMacro extends AbstractMacro {
 		registerCommand(new MacroCommand(buildSetLoggingAttributesCommand(configuration), "Setting the logging attributes."));
 		registerCommand(new MacroMacroCommand(new JmsResourcesMacro(configuration), "Managing JMS Resources."));
 		registerCommand(new MacroMacroCommand(new JdbcResourcesMacro(configuration), "Managing JDBC Resources."));
+		if(configuration.getDeployConfiguration() != null) {
+			registerCommand(new MacroMacroCommand(new DeployMacro(configuration), "Deploying resource adapter."));
+		}
+		registerCommand(new MacroMacroCommand(new ConnectorConnectionPoolsMacro(configuration), "Creating Connectors Connection Pools."));
 		registerCommand(new MacroCommand(buildStopDomainCommand(configuration), "Stopping domain."));
 	}
 }

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/macro/DeployResourceAdapterMacro.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/macro/DeployResourceAdapterMacro.java
@@ -20,5 +20,10 @@ public class DeployResourceAdapterMacro extends AbstractMacro {
 	public DeployResourceAdapterMacro(Configuration configuration, ResourceAdapter resourceAdapter) {
 		super(configuration);
 		registerCommand(new MacroCommand(buildDeployCommand(configuration, resourceAdapter.getDeployConfig()), "Deploying resource adapter [" + resourceAdapter.getDeployConfig().getName() + "]."));
+		
+		// Configure if properties are set
+		if(resourceAdapter.hasProperties()) {
+			registerCommand(new MacroCommand(buildCreateAdapterConfigCommand(configuration, resourceAdapter), "Create configuration for resource adapter [" + resourceAdapter.getDeployConfig().getName() + "]."));
+		}	
 	}
 }

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/macro/DeployResourceAdapterMacro.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/macro/DeployResourceAdapterMacro.java
@@ -1,0 +1,24 @@
+package com.lotaris.maven.plugin.glassfish.macro;
+
+import com.lotaris.maven.plugin.glassfish.model.Configuration;
+import com.lotaris.maven.plugin.glassfish.model.ResourceAdapter;
+
+import static com.lotaris.maven.plugin.glassfish.command.CommandFactory.*;
+
+/**
+ * Deploy resource adapter macro
+ * 
+ * @author Valentin Delaye <valentin.delaye@novaccess.ch>
+ */
+public class DeployResourceAdapterMacro extends AbstractMacro {
+	/**
+	 * Constructor
+	 * 
+	 * @param configuration The configuration
+	 * @param resourceAdapter The resource adapter to deploy
+	 */
+	public DeployResourceAdapterMacro(Configuration configuration, ResourceAdapter resourceAdapter) {
+		super(configuration);
+		registerCommand(new MacroCommand(buildDeployCommand(configuration, resourceAdapter.getDeployConfig()), "Deploying resource adapter [" + resourceAdapter.getDeployConfig().getName() + "]."));
+	}
+}

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/macro/ResourceAdaptersMacro.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/macro/ResourceAdaptersMacro.java
@@ -1,0 +1,27 @@
+package com.lotaris.maven.plugin.glassfish.macro;
+
+import com.lotaris.maven.plugin.glassfish.model.Configuration;
+import com.lotaris.maven.plugin.glassfish.model.ResourceAdapter;
+
+
+/**
+ * The Resource Adapter macro manage the deployment of the different resource adapter for a domain.
+ *  
+ * @author Valentin Delaye <valentin.delaye@novaccess.ch>
+ */
+public class ResourceAdaptersMacro extends AbstractMacro {
+
+	public ResourceAdaptersMacro(Configuration configuration) {
+		super(configuration);
+		
+		// Configure the JMS Hosts if there are some
+		if (configuration.getDomain().hasResourceAdapters()) {
+			for (ResourceAdapter resourceAdapter : configuration.getDomain().getResourceAdapters()) {
+				// Create and register the command
+				registerCommand(new MacroMacroCommand(new DeployResourceAdapterMacro(configuration, resourceAdapter), "Deploying resource adapter."));
+			}
+		}
+		
+	}
+
+}

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/AdminObject.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/AdminObject.java
@@ -65,7 +65,16 @@ public class AdminObject {
 
 	@Override
 	public String toString() {
-		return "jndiName=" + jndiName + ", raname=" + raname + ", restype=" + restype + '}';
+		StringBuilder builder = new StringBuilder();
+		if(properties != null) {
+			for (Property p : properties) {
+				builder.append(p).append(", ");
+			}		
+		}
+		return 
+			"jndiName=" + jndiName + ", " +
+			"raname=" + raname + "," +
+			"restype=" + restype + "," +
+			"properties=" + builder.toString();
 	}
-	
 }

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/AdminObject.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/AdminObject.java
@@ -1,0 +1,71 @@
+package com.lotaris.maven.plugin.glassfish.model;
+
+import java.util.Set;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Represents an admin object and configuration required for its creation.
+ * 
+ * @author Valentin Delaye <valentin.delaye@novaccess.ch>
+ */
+public class AdminObject {
+
+	/**
+	 * JNDI name of the admin object
+	 */
+	@Parameter(required = true)
+	private String jndiName;
+	
+	/**
+	 * Name of the resource adapter to use
+	 */
+	@Parameter(required = true)
+	private String raname;
+	
+	/**
+	 * Type (class name) of the resource
+	 */
+	@Parameter(required = true)
+	private String restype;
+	
+	@Parameter
+	private Set<Property> properties;
+
+	public String getJndiName() {
+		return jndiName;
+	}
+
+	public void setJndiName(String jndiName) {
+		this.jndiName = jndiName;
+	}
+
+	public String getRaname() {
+		return raname;
+	}
+
+	public void setRaname(String raname) {
+		this.raname = raname;
+	}
+
+	public String getRestype() {
+		return restype;
+	}
+
+	public void setRestype(String restype) {
+		this.restype = restype;
+	}
+
+	public Set<Property> getProperties() {
+		return properties;
+	}
+
+	public void setProperties(Set<Property> properties) {
+		this.properties = properties;
+	}
+
+	@Override
+	public String toString() {
+		return "jndiName=" + jndiName + ", raname=" + raname + ", restype=" + restype + '}';
+	}
+	
+}

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/ConnectorConnectionPool.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/ConnectorConnectionPool.java
@@ -1,5 +1,6 @@
 package com.lotaris.maven.plugin.glassfish.model;
 
+import java.util.Set;
 import org.apache.maven.plugins.annotations.Parameter;
 
 /**
@@ -37,6 +38,9 @@ public class ConnectorConnectionPool {
 	 */
 	@Parameter(required = false, defaultValue = "true")
 	private Boolean isConnectValidateReq;
+	
+	@Parameter
+	private Set<Property> properties;
 
 	public String getJndiName() {
 		return jndiName;
@@ -76,6 +80,14 @@ public class ConnectorConnectionPool {
 
 	public void setIsConnectValidateReq(Boolean isConnectValidateReq) {
 		this.isConnectValidateReq = isConnectValidateReq;
+	}
+
+	public Set<Property> getProperties() {
+		return properties;
+	}
+
+	public void setProperties(Set<Property> properties) {
+		this.properties = properties;
 	}
 
 	@Override

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/ConnectorConnectionPool.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/ConnectorConnectionPool.java
@@ -93,11 +93,12 @@ public class ConnectorConnectionPool {
 
 	@Override
 	public String toString() {
-		return "jndiName=" + jndiName +
-			", raname=" + raname +
-			", connectionDefinition=" + connectionDefinition +
-			", ping=" + ping +
-			", isConnectValidateReq=" + isConnectValidateReq + '}';
+		return 
+			"jndiName=" + jndiName + ", " +
+			"raname=" + raname + ", " +
+			"connectionDefinition=" + connectionDefinition +
+			"ping=" + ping + ", " +
+			"isConnectValidateReq=" + isConnectValidateReq;
 	}
 	
 }

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/ConnectorConnectionPool.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/ConnectorConnectionPool.java
@@ -4,7 +4,8 @@ import java.util.Set;
 import org.apache.maven.plugins.annotations.Parameter;
 
 /**
- *
+ * Represents a connector connection pool and configuration required its creation.
+ * 
  * @author Valentin Delaye <valentin.delaye@novaccess.ch>
  */
 public class ConnectorConnectionPool {
@@ -25,7 +26,7 @@ public class ConnectorConnectionPool {
 	 * The name of the connection definition
 	 */
 	@Parameter(required = true)
-	private ConnectionFactory.Type connectionDefinition;
+	private String connectionDefinition;
 	
 	/**
 	 * Ping during creation of the connection pool
@@ -58,11 +59,11 @@ public class ConnectorConnectionPool {
 		this.raname = raname;
 	}
 
-	public ConnectionFactory.Type getConnectionDefinition() {
+	public String getConnectionDefinition() {
 		return connectionDefinition;
 	}
 
-	public void setConnectionDefinition(ConnectionFactory.Type connectionDefinition) {
+	public void setConnectionDefinition(String connectionDefinition) {
 		this.connectionDefinition = connectionDefinition;
 	}
 

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/ConnectorConnectionPool.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/ConnectorConnectionPool.java
@@ -1,0 +1,90 @@
+package com.lotaris.maven.plugin.glassfish.model;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ *
+ * @author Valentin Delaye <valentin.delaye@novaccess.ch>
+ */
+public class ConnectorConnectionPool {
+
+	/**
+	 * JNDI name of the connector connector pool
+	 */
+	@Parameter(required = true)
+	private String jndiName;
+	
+	/**
+	 * Name of the resource adapter
+	 */
+	@Parameter(required = true)
+	private String raname;
+	
+	/**
+	 * The name of the connection definition
+	 */
+	@Parameter(required = true)
+	private ConnectionFactory.Type connectionDefinition;
+	
+	/**
+	 * Ping during creation of the connection pool
+	 */
+	@Parameter(required = false, defaultValue = "true")
+	private Boolean ping;
+	
+	/**
+	 * Ping during creation of the connection pool
+	 */
+	@Parameter(required = false, defaultValue = "true")
+	private Boolean isConnectValidateReq;
+
+	public String getJndiName() {
+		return jndiName;
+	}
+
+	public void setJndiName(String jndiName) {
+		this.jndiName = jndiName;
+	}
+
+	public String getRaname() {
+		return raname;
+	}
+
+	public void setRaname(String raname) {
+		this.raname = raname;
+	}
+
+	public ConnectionFactory.Type getConnectionDefinition() {
+		return connectionDefinition;
+	}
+
+	public void setConnectionDefinition(ConnectionFactory.Type connectionDefinition) {
+		this.connectionDefinition = connectionDefinition;
+	}
+
+	public Boolean getPing() {
+		return ping;
+	}
+
+	public void setPing(Boolean ping) {
+		this.ping = ping;
+	}
+
+	public Boolean getIsConnectValidateReq() {
+		return isConnectValidateReq;
+	}
+
+	public void setIsConnectValidateReq(Boolean isConnectValidateReq) {
+		this.isConnectValidateReq = isConnectValidateReq;
+	}
+
+	@Override
+	public String toString() {
+		return "jndiName=" + jndiName +
+			", raname=" + raname +
+			", connectionDefinition=" + connectionDefinition +
+			", ping=" + ping +
+			", isConnectValidateReq=" + isConnectValidateReq + '}';
+	}
+	
+}

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/ConnectorResource.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/ConnectorResource.java
@@ -1,0 +1,57 @@
+package com.lotaris.maven.plugin.glassfish.model;
+
+import java.util.Set;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Represents a connector resource and configuration required for its creation.
+ * 
+ * @author Valentin Delaye <valentin.delaye@novaccess.ch>
+ */
+public class ConnectorResource {
+
+	/**
+	 * JNDI name of the connector resource
+	 */
+	@Parameter(required = true)
+	private String jndiName;
+	
+	/**
+	 * Name of the referenced connector connection pool name
+	 */
+	@Parameter(required = true)
+	private String poolName;
+	
+	@Parameter
+	private Set<Property> properties;
+
+	public String getJndiName() {
+		return jndiName;
+	}
+
+	public void setJndiName(String jndiName) {
+		this.jndiName = jndiName;
+	}
+
+	public String getPoolName() {
+		return poolName;
+	}
+
+	public void setPoolName(String poolName) {
+		this.poolName = poolName;
+	}
+
+	public Set<Property> getProperties() {
+		return properties;
+	}
+
+	public void setProperties(Set<Property> properties) {
+		this.properties = properties;
+	}
+
+	@Override
+	public String toString() {
+		return "jndiName=" + jndiName + ", poolName=" + poolName + '}';
+	}
+	
+}

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/ConnectorResource.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/ConnectorResource.java
@@ -52,15 +52,17 @@ public class ConnectorResource {
 	@Override
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
+		String props = null;
 		if(properties != null) {
 			for (Property p : properties) {
 				builder.append(p).append(", ");
-			}		
+			}
+			props = builder.toString().replaceAll(", $", "");
 		}
 		return 
 			"jndiName=" + jndiName + ", " +
 			"poolName=" + poolName  + ", " +
-			"properties=" + builder.toString();
+			"properties=" + props;
 	}
 	
 }

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/ConnectorResource.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/ConnectorResource.java
@@ -51,7 +51,16 @@ public class ConnectorResource {
 
 	@Override
 	public String toString() {
-		return "jndiName=" + jndiName + ", poolName=" + poolName + '}';
+		StringBuilder builder = new StringBuilder();
+		if(properties != null) {
+			for (Property p : properties) {
+				builder.append(p).append(", ");
+			}		
+		}
+		return 
+			"jndiName=" + jndiName + ", " +
+			"poolName=" + poolName  + ", " +
+			"properties=" + builder.toString();
 	}
 	
 }

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/Domain.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/Domain.java
@@ -135,6 +135,12 @@ public class Domain {
 	private Set<ConnectorConnectionPool> connectorConnectionPools;
 	
 	/**
+	 * Define a set of connector resource to create
+	 */
+	@Parameter
+	private Set<ConnectorResource> connectorResources;
+	
+	/**
 	 * A list of JMS resources to create (resources + physical destinations)
 	 */
 	@Parameter
@@ -239,6 +245,18 @@ public class Domain {
 	public boolean hasConnectorConnectionPools() {
 		return connectorConnectionPools != null && !connectorConnectionPools.isEmpty();
 	}
+
+	public Set<ConnectorResource> getConnectorResources() {
+		return connectorResources;
+	}
+
+	public void setConnectorResources(Set<ConnectorResource> connectorResources) {
+		this.connectorResources = connectorResources;
+	}
+	
+	public boolean hasConnectorResources() {
+		return connectorResources != null && !connectorResources.isEmpty();
+	}	
 
 	public Set<ResourceAdapter> getResourceAdapters() {
 		return resourceAdapters;

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/Domain.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/Domain.java
@@ -158,6 +158,12 @@ public class Domain {
 	@Parameter
 	private Set<ResourceAdapter> resourceAdapters;
 	
+	/**
+	 * A list of admin object to create
+	 */
+	@Parameter
+	private Set<AdminObject> adminObjects;
+	
 	public String getName() {
 		return name;
 	}
@@ -269,6 +275,18 @@ public class Domain {
 	public boolean hasResourceAdapters() {
 		return resourceAdapters != null && !resourceAdapters.isEmpty();
 	}
+
+	public Set<AdminObject> getAdminObjects() {
+		return adminObjects;
+	}
+
+	public void setAdminObjects(Set<AdminObject> adminObjects) {
+		this.adminObjects = adminObjects;
+	}
+	
+	public boolean hasAdminObjects() {
+		return adminObjects != null && !adminObjects.isEmpty();
+	}	
 	
 	/**
 	 * @return True if the domain exists (if the directory of the domain exists)

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/Domain.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/Domain.java
@@ -327,6 +327,12 @@ public class Domain {
 
 	@Override
 	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		if(properties != null) {
+			for (Property p : properties) {
+				builder.append(p).append(", ");
+			}		
+		}
 		return 
 			"createJvmOptions=" + createJvmOptions + ", " +
 			"adminPort=" + adminPort + ", " + 
@@ -346,7 +352,7 @@ public class Domain {
 			"jmxPort=" + jmxPort + ", " + 
 			"loggingAttributes=" + loggingAttributes + ", " +
 			"name=" + name + ", " + 
-			"properties=" + properties + ", " +
-			"reuse=" + reuse;
+			"reuse=" + reuse + ", " +
+			"properties=" + builder.toString();
 	}
 }

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/Domain.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/Domain.java
@@ -129,6 +129,12 @@ public class Domain {
 	private Set<ConnectionFactory> connectionFactories;
 	
 	/**
+	 * Define a set of connector connection pool to create
+	 */
+	@Parameter
+	private Set<ConnectorConnectionPool> connectorConnectionPools;
+	
+	/**
 	 * A list of JMS resources to create (resources + physical destinations)
 	 */
 	@Parameter
@@ -214,6 +220,18 @@ public class Domain {
 
 	public Set<JdbcResource> getJdbcResources() {
 		return jdbcResources;
+	}
+	
+	public Set<ConnectorConnectionPool> getConnectorConnectionPools() {
+		return connectorConnectionPools;
+	}
+
+	public void setConnectorConnectionPools(Set<ConnectorConnectionPool> connectorConnectionPools) {
+		this.connectorConnectionPools = connectorConnectionPools;
+	}
+	
+	public boolean hasConnectorConnectionPools() {
+		return connectorConnectionPools != null && !connectorConnectionPools.isEmpty();
 	}
 	
 	/**

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/Domain.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/Domain.java
@@ -146,6 +146,12 @@ public class Domain {
 	@Parameter
 	private Set<JdbcResource> jdbcResources;
 	
+	/**
+	 * A list of Resource Adapter to deploy on the domain
+	 */
+	@Parameter
+	private Set<ResourceAdapter> resourceAdapters;
+	
 	public String getName() {
 		return name;
 	}
@@ -232,6 +238,18 @@ public class Domain {
 	
 	public boolean hasConnectorConnectionPools() {
 		return connectorConnectionPools != null && !connectorConnectionPools.isEmpty();
+	}
+
+	public Set<ResourceAdapter> getResourceAdapters() {
+		return resourceAdapters;
+	}
+
+	public void setResourceAdapters(Set<ResourceAdapter> resourceAdapters) {
+		this.resourceAdapters = resourceAdapters;
+	}
+	
+	public boolean hasResourceAdapters() {
+		return resourceAdapters != null && !resourceAdapters.isEmpty();
 	}
 	
 	/**

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/Domain.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/Domain.java
@@ -328,10 +328,12 @@ public class Domain {
 	@Override
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
+		String props = null;
 		if(properties != null) {
 			for (Property p : properties) {
 				builder.append(p).append(", ");
-			}		
+			}
+			props = builder.toString().replaceAll(", $", "");
 		}
 		return 
 			"createJvmOptions=" + createJvmOptions + ", " +
@@ -353,6 +355,6 @@ public class Domain {
 			"loggingAttributes=" + loggingAttributes + ", " +
 			"name=" + name + ", " + 
 			"reuse=" + reuse + ", " +
-			"properties=" + builder.toString();
+			"properties=" + props;
 	}
 }

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/Glassfish.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/Glassfish.java
@@ -1,7 +1,3 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package com.lotaris.maven.plugin.glassfish.model;
 
 import java.io.File;
@@ -88,7 +84,7 @@ public class Glassfish {
 	 */
 	@Parameter
 	private Set<JmsHost> jmsHosts;
-	
+		
 	/**
 	 * Represent information to configure the JMS service
 	 */
@@ -154,7 +150,7 @@ public class Glassfish {
 	public Set<JmsHost> getJmsHosts() {
 		return jmsHosts;
 	}
-
+	
 	public JmsService getJmsService() {
 		return jmsService;
 	}

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/ResourceAdapter.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/ResourceAdapter.java
@@ -1,0 +1,26 @@
+package com.lotaris.maven.plugin.glassfish.model;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Configuration for a resource adapter.
+ * 
+ * @author Valentin Delaye <valentin.delaye@novaccess.ch>
+ */
+public class ResourceAdapter {
+	
+	/**
+	 * The deploy configuration for the resource adapter
+	 */
+	@Parameter(required = true)
+	private DeployConfiguration deployConfig;
+
+	public DeployConfiguration getDeployConfig() {
+		return deployConfig;
+	}
+
+	public void setDeployConfig(DeployConfiguration deployConfig) {
+		this.deployConfig = deployConfig;
+	}
+
+}

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/ResourceAdapter.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/ResourceAdapter.java
@@ -42,4 +42,19 @@ public class ResourceAdapter {
 		this.deployConfig = deployConfig;
 	}
 
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		String props = null;
+		if(properties != null) {
+			for (Property p : properties) {
+				builder.append(p).append(", ");
+			}
+			props = builder.toString().replaceAll(", $", "");
+		}
+		return 
+			"deployConfig=" + deployConfig + ", " +
+			"properties=" + props;
+	}
+	
 }

--- a/src/main/java/com/lotaris/maven/plugin/glassfish/model/ResourceAdapter.java
+++ b/src/main/java/com/lotaris/maven/plugin/glassfish/model/ResourceAdapter.java
@@ -1,5 +1,6 @@
 package com.lotaris.maven.plugin.glassfish.model;
 
+import java.util.Set;
 import org.apache.maven.plugins.annotations.Parameter;
 
 /**
@@ -14,7 +15,25 @@ public class ResourceAdapter {
 	 */
 	@Parameter(required = true)
 	private DeployConfiguration deployConfig;
+	
+	/**
+	 * A set of additional properties to configure
+	 */
+	@Parameter
+	private Set<Property> properties;
 
+	public Set<Property> getProperties() {
+		return properties;
+	}
+
+	public void setProperties(Set<Property> properties) {
+		this.properties = properties;
+	}
+	
+	public boolean hasProperties() {
+		return this.properties != null && !this.properties.isEmpty();
+	}
+	
 	public DeployConfiguration getDeployConfig() {
 		return deployConfig;
 	}


### PR DESCRIPTION
The glassfish plugin now support the deployment of a resource adapter (RA) when creating the domain. It also support 4 new commands (create-resource-adapter-config, create-connector-connection-pool, create-connector-resource, create-admin-object) to configure this resource adapter and connectors.

This PR does not break compatibility with 1.2.*. It only adds new configuration.

A typical use case for this is to configure Glassfish to use an ActiveMQ JMS broker (Tested with Apache Apollo : http://activemq.apache.org/integrating-apache-activemq-with-glassfish.html

Some examples :

**Deploy RA archive when creating the domain**

```
<domain>

....

<resourceAdapters>

    <!-- Deploy and configure 0 or more RA -->
    <resourceAdapter>

        <!-- The deploy configuration -->
        <deployConfig>
            <name>activemq-rar</name>
            <file>activemq-rar-5.13.1.rar</file>
            <type>rar</type>
            <force>true</force>
        </deployConfig>

        <!-- The properties to configure the resource adapter -->
        <properties>
            <property>
                <name>UserName</name>
                <value>TheUserName</value>
            </property>
            <property>
                <name>Password</name>
                <value>ThePassword</value>
            </property>
            <property>
                <name>ServerUrl</name>
                <value>tcp://10.10.10.10:61614?jms.useCompression=true</value>
            </property>
        </properties>
    </resourceAdapter>
</resourceAdapters>

...

</domain>
```

**Create connector connection pool and associated connector resource**

```
<domain>

...

<!-- Connector connection pool -->
<connectorConnectionPools>

    <connectorConnectionPool>
        <raname>activemq-rar</raname>
        <jndiName>jms/my-queue-pool</jndiName>
        <ping>true</ping>
        <isConnectValidateReq>true</isConnectValidateReq>
        <connectionDefinition>javax.jms.ConnectionFactory</connectionDefinition>
        <properties>
            <property>
                <name>Description</name>
                <value>My connector connection pool</value>
            </property>
        </properties>
    </connectorConnectionPool>

</connectorConnectionPools>

<!-- Connector resources -->
<connectorResources>

    <connectorResource>
        <poolName>jms/my-queue-pool</poolName>
        <jndiName>jms/my-queue-resource</jndiName>
    </connectorResource>

</connectorResources>

..

</domain>
```

**Create an admin object for ActiveMQ with physical queue name**

```
<adminObjects>

    <adminObject>
        <raname>activemq-rar</raname>
        <jndiName>jms/queue/my-queue-jndi-name</jndiName>
        <restype>javax.jms.Queue</restype>
        <properties>
            <property>
                <name>PhysicalName</name>
                <value>thePhysicalQueueName</value>
            </property>
        </properties>                                           
    </adminObject>

</adminObjects>
```

Just for the example an MDB can be deployed in glassfish with following config

```
@MessageDriven(
        activationConfig = {
            @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
            @ActivationConfigProperty(propertyName = "destination", propertyValue = "jms/queue/my-queue-jndi-name"),
            @ActivationConfigProperty(propertyName = "useJndi", propertyValue = "true")
        }
)
public class MyMDB implements MessageListener {
    // DO Something
}
```

glassfish-ejb-jar

```
<glassfish-ejb-jar>
    <enterprise-beans>
        <ejb>
            <ejb-name>MyMDB</ejb-name>
            <mdb-connection-factory>
                <jndi-name>jms/queue/my-queue-jndi-name</jndi-name>
            </mdb-connection-factory>
            <mdb-resource-adapter>
                <resource-adapter-mid>activemq-rar</resource-adapter-mid>
            </mdb-resource-adapter>
        </ejb>
    </enterprise-beans>
</glassfish-ejb-jar>
```
